### PR TITLE
Upped timezone version

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
     "node": ">= 0.6"
   },
   "dependencies": {
-    "geolib": "1.2.5",
-    "simplesets": "1.2.0",
-    "timezone": "0.0.19"
+    "geolib": "1.x",
+    "simplesets": "1.x",
+    "timezone": "0.x"
   },
   "devDependencies": {
     "mocha": "1.x"


### PR DESCRIPTION
Current `timezone@0.0.19` module have outdated tzinfo.
Notably for Russian Federaion. RU have no more dst switches.
With 0.0.41 it works fine.
